### PR TITLE
fix the 'get_historical_interest' error

### DIFF
--- a/pytrends/request.py
+++ b/pytrends/request.py
@@ -473,8 +473,7 @@ class TrendReq(object):
         """Gets historical hourly data for interest by chunking requests to 1 week at a time (which is what Google allows)"""
 
         # construct datetime obejcts - raises ValueError if invalid parameters
-        initial_start_date = start_date = datetime(year_start, month_start,
-                                                   day_start, hour_start)
+        start_date = datetime(year_start, month_start, day_start, hour_start)
         end_date = datetime(year_end, month_end, day_end, hour_end)
 
         # the timeframe has to be in 1 week intervals or Google will reject it
@@ -482,17 +481,14 @@ class TrendReq(object):
 
         df = pd.DataFrame()
 
-        date_iterator = start_date
-        date_iterator += delta
-
-        while True:
-            # format date to comply with API call
+        date_iterator = start_date + delta
+        
+        while (start_date < end_date):
 
             start_date_str = start_date.strftime('%Y-%m-%dT%H')
             date_iterator_str = date_iterator.strftime('%Y-%m-%dT%H')
-
             tf = start_date_str + ' ' + date_iterator_str
-
+            print(tf)
             try:
                 self.build_payload(keywords, cat, tf, geo, gprop)
                 week_df = self.interest_over_time()
@@ -503,25 +499,7 @@ class TrendReq(object):
 
             start_date += delta
             date_iterator += delta
-
-            if (date_iterator > end_date):
-                # Run for 7 more days to get remaining data that would have been truncated if we stopped now
-                # This is needed because google requires 7 days yet we may end up with a week result less than a full week
-                start_date_str = start_date.strftime('%Y-%m-%dT%H')
-                date_iterator_str = date_iterator.strftime('%Y-%m-%dT%H')
-
-                tf = start_date_str + ' ' + date_iterator_str
-
-                try:
-                    self.build_payload(keywords, cat, tf, geo, gprop)
-                    week_df = self.interest_over_time()
-                    df = df.append(week_df)
-                except Exception as e:
-                    print(e)
-                    pass
-                break
-
-            # just in case you are rate-limited by Google. Recommended is 60 if you are.
+        # just in case you are rate-limited by Google. Recommended is 60 if you are.
             if sleep > 0:
                 time.sleep(sleep)
 

--- a/pytrends/request.py
+++ b/pytrends/request.py
@@ -473,7 +473,7 @@ class TrendReq(object):
         """Gets historical hourly data for interest by chunking requests to 1 week at a time (which is what Google allows)"""
 
         # construct datetime obejcts - raises ValueError if invalid parameters
-        start_date = datetime(year_start, month_start, day_start, hour_start)
+        initial_start_date = start_date = datetime(year_start, month_start, day_start, hour_start)
         end_date = datetime(year_end, month_end, day_end, hour_end)
 
         # the timeframe has to be in 1 week intervals or Google will reject it


### PR DESCRIPTION
The last iteration will sometimes cause the error:
'The request failed: Google returned a response with code 400.' 
Due to the requested timeframe is completely in the future date.


For example, the following code:
```kw_list=['pizza']
pytrend = TrendReq(hl='en-US')
out = pytrend.get_historical_interest(kw_list, year_start=2019, month_start=11,
                                day_start=11, hour_start=1, year_end=2019,
                                month_end=11, day_end=17, hour_end=0, cat=0,
                                geo='', gprop='', sleep=0)
out.shape
```
 
will return:
The request failed: Google returned a response with code 400.
Out[432]:
(127, 2)

Simplify the while loop to remove the extra iteration and only execute request when the start_date < end_date.